### PR TITLE
2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,114 @@
-# wurfl-microservice-client-scala
-WURFL Microservice client API for Scala
+### WURFL Microservice client for Scala
+
+WURFL Microservice (by ScientiaMobile, Inc.) is a mobile device detection service that can quickly and accurately detect over 500 capabilities of visiting devices. It can differentiate between portable mobile devices, desktop devices, SmartTVs and any other types of devices that have a web browser.
+
+This is the Scala Client API for accessing the WURFL Microservice. The Scala works as a wrapper of the Java client API on which it depends (see the sbt or maven build files). 
+The API is released under Open-Source and can be integrated with other open-source or proprietary code. In order to operate, it requires access to a running instance of the WURFL Microservice product, such as:
+
+- WURFL Microservice for Docker: https://www.scientiamobile.com/products/wurfl-microservice-docker-detect-device/
+
+- WURFL Microservice for AWS: https://www.scientiamobile.com/products/wurfl-device-detection-microservice-aws/ 
+
+- WURFL Microservice for Azure: https://www.scientiamobile.com/products/wurfl-microservice-for-azure/
+
+- WURFL Microservice for Google Cloud Platform: https://www.scientiamobile.com/products/wurfl-microservice-for-gcp/
+
+Scala implementation of the WM Client api.
+Requires Scala 2.13 and Java 8 or above.
+
+The Example project contains an example of client api usage for a console application :
+
+```scala
+import com.scientiamobile.wurfl.wmclient.WmException
+import com.scientiamobile.wurfl.wmclient.scala.WmClient
+
+import scala.util.Sorting.quickSort
+
+object Example {
+
+  def main(args: Array[String]) {
+    print("Running scala version ")
+    println(scala.util.Properties.scalaPropOrElse("version.number", "unknown scala version"))
+
+    try { // First we need to create a WM client instance, to connect to our WM server API at the specified host and port.
+      val client = WmClient.apply("http", "localhost", "8080", "")
+      // We ask Wm server API for some Wm server info such as server API version and info about WURFL API and file used by WM server.
+      val info = client.getInfo()
+      println("Printing WM server information")
+      println("WURFL API version: " + info.getWurflApiVersion)
+      println("WM server version:  " + info.getWmVersion)
+      println("Wurfl file info: " + info.getWurflInfo)
+      val ua = "Mozilla/5.0 (Linux; Android 7.1.1; ONEPLUS A5000 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36"
+      // By setting the cache size we are also activating the caching option in WM client. In order to not use cache, you just to need to omit setCacheSize call
+      client.setCacheSize(100000)
+      // set the capabilities we want to receive from WM server
+      client.setRequestedStaticCapabilities(Array[String]("brand_name", "model_name"))
+      client.setRequestedVirtualCapabilities(Array[String]("is_smartphone", "form_factor"))
+      println
+      println("Detecting device for user-agent: " + ua)
+      // Perform a device detection calling WM server API
+      val device = client.lookupUseragent(ua)
+      // Applicative error, ie: invalid input provided
+      if (device.error != null && device.error.length > 0) println("An error occurred: " + device.error)
+      else { // Let's get the device capabilities and print some of them
+        val capabilities = device.capabilities
+        println("Detected device WURFL ID: " + capabilities.get("wurfl_id"))
+        println("Device brand & model: " + capabilities.get("brand_name") + " " + capabilities.get("model_name"))
+        println("Detected device form factor: " + capabilities.get("form_factor"))
+        if (capabilities.get("is_smartphone").equals("true")) println("This is a smartphone")
+        // Iterate over all the device capabilities and print them
+        println("All received capabilities")
+        val it = capabilities.keySet.iterator
+        while ( {
+          it.hasNext
+        }) {
+          val k = it.next
+          println(k + ": " + capabilities.get(k))
+        }
+      }
+      // Get all the device manufacturers, and print the first twenty
+      val limit = 20
+      val deviceMakes = client.getAllDeviceMakes
+      printf("Print the first %d Brand of %d retrieved from server\n", limit, deviceMakes.length)
+      // Sort the device manufacturer names
+      quickSort(deviceMakes)
+      for (i <- 0 until limit) {
+        printf(" - %s\n", deviceMakes(i))
+      }
+      // Now call the WM server to get all device model and marketing names produced by Apple
+      println("Print all Model for the Apple Brand")
+      val devNames = client.getAllDevicesForMake("Apple")
+      // Sort ModelMktName objects by their model name
+      devNames.sortWith(_.modelName >= _.modelName)
+
+      for (modelMktName <- devNames) {
+        printf(" - %s %s\n", modelMktName.modelName, modelMktName.marketingName)
+      }
+      // Now call the WM server to get all operative system names
+      println("Print the list of OSes")
+      val oses = client.getAllOSes
+      // Sort and print all OS names
+      quickSort(oses)
+      for (os <- oses) {
+        printf(" - %s\n", os)
+      }
+      // Let's call the WM server to get all version of the Android OS
+      println("Print all versions for the Android OS")
+      val osVersions = client.getAllVersionsForOS("Android")
+      // Sort all Android version numbers and print them.
+      quickSort(osVersions)
+      for (ver <- osVersions) {
+        printf(" - %s\n", ver)
+      }
+      // Cleans all client resources. Any call on client API methods after this one will throw a WmException
+      client.destroyConnection
+    } catch {
+      case e: WmException =>
+        // problems such as network errors  or internal server problems
+        // note that WmException comes from the Java wrapped API
+        println("An error has occurred: " + e.getMessage)
+    }
+  }
+}
+```
+

--- a/wmclient/CHANGELOG.txt
+++ b/wmclient/CHANGELOG.txt
@@ -1,0 +1,3 @@
+2.1.0
+----------------------------------------------
+- First version: wrapped all methods from WURFL Microservice Java client

--- a/wmclient/LICENSE.txt
+++ b/wmclient/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018 Scientiamobile Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/wmclient/pom.xml
+++ b/wmclient/pom.xml
@@ -126,14 +126,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <!-- <version>2.2.1</version> <configuration> <source>1.5</source>
-                <target>1.5</target> <encoding>UTF-8</encoding> </configuration> parte del
-                source plugin -->
                 <executions>
                     <execution>
                         <id>attach-sources</id>
                         <phase>package</phase>
-                        <!-- <phase>verify</phase> -->
                         <goals>
                             <goal>jar</goal>
                         </goals>
@@ -175,6 +171,69 @@
 
         </plugins>
     </build>
+
+    <profiles>
+
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+
+                    <!-- check for license header in all (but excluded) files -->
+                    <plugin>
+                        <groupId>com.mycila.maven-license-plugin</groupId>
+                        <artifactId>maven-license-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>2.0.2</version>
+                        <configuration>
+                            <source>1.8</source>
+                            <target>1.8</target>
+                            <encoding>UTF-8</encoding>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
+
 </project>
 
         <!--

--- a/wmclient/pom.xml
+++ b/wmclient/pom.xml
@@ -215,15 +215,15 @@
                             </execution>
                         </executions>
                     </plugin>
-
                     <plugin>
-                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <groupId>net.alchim31.maven</groupId>
+                        <artifactId>scala-maven-plugin</artifactId>
+                        <version>4.4.0</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
-                                <phase>package</phase>
                                 <goals>
-                                    <goal>jar</goal>
+                                    <goal>doc-jar</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/wmclient/src/main/scala/com/scientiamobile/wurfl/wmclient/scala/WmClient.scala
+++ b/wmclient/src/main/scala/com/scientiamobile/wurfl/wmclient/scala/WmClient.scala
@@ -29,56 +29,55 @@ class WmClient(private var wmjclient: com.scientiamobile.wurfl.wmclient.WmClient
   def lookupUseragent(userAgent: String): Model#JSONDeviceData = wmjclient.lookupUseragent(userAgent)
 
   /**
-   * Performs a device detection using an HTTP request object, as passed from Java Web applications
+   * Performs a device detection using an HTTP request object, as passed from Java Web applications.
+   * Throws WmException In case a connection error occurs, malformed data are sent, or the given brand name parameter does not exist in WM server.
    *
    * @param request an instance of HTTPServletRequest
    * @return An object containing the device capabilities
-   * @throws WmException In case any error occurs during device detection
    */
   def lookupRequest(request: HttpServletRequest): Model#JSONDeviceData = wmjclient.lookupRequest(request)
 
   /**
-   * @return A JSONInfoData instance holding the capabilities exposed from WM server, the headers used for device detection, WURFL file and API version
-   * @throws WmException If server cannot send data or incomplete data are sent
+   * @return A JSONInfoData instance holding the capabilities exposed from WM server, the headers used for device detection, WURFL file and API version.
+   *         Throws WmException In case a connection error occurs, malformed data are sent, or the given brand name parameter does not exist in WM server.
    */
   def getInfo(): Model#JSONInfoData = wmjclient.getInfo
 
   /**
-   * Returns the device matching the given WURFL ID
+   * Returns the device matching the given WURFL ID.
+   * Throws WmException In case a connection error occurs, malformed data are sent, or the given brand name parameter does not exist in WM server.
    *
    * @param deviceId a WURFL device identifier
    * @return An object containing the device capabilities
-   * @throws WmException In case any error occurs
    */
   def lookupDeviceId(deviceId:String): Model#JSONDeviceData = wmjclient.lookupDeviceId(deviceId)
 
   /**
    * Performs a device detection using a map containing the http request headers.
    * Headers are handled as case insensitive (ie: header name "User-Agent" is equal to "UsEr-aGent")
+   * Throws WmException In case a connection error occurs, malformed data are sent, or the given brand name parameter does not exist in WM server.
    *
    * @param headers an instance of HTTPServletRequest
    * @return An object containing the device capabilities
-   * @throws WmException In case any error occurs during device detection
    */
   def lookupHeaders (headers: util.Map[String, String]): Model#JSONDeviceData = wmjclient.lookupHeaders(headers)
 
   /**
-   * @return getAllDeviceMakes returns a string array of all devices brand_name capabilities in WM server
-   * @throws WmException In case a connection error occurs or malformed data are sent
+   * @return getAllDeviceMakes returns a string array of all devices brand_name capabilities in WM server. Throws WmException In case a connection error occurs, malformed data are sent,
+   *         or the given brand name parameter does not exist in WM server.
    */
   def getAllDeviceMakes(): Array[String] = wmjclient.getAllDeviceMakes
 
   /**
    * @param make a brand name
-   * @return An array of {@link com.scientiamobile.wurfl.wmclient.Model#JSONModelMktName} that contain values for model_name
-   *         and marketing_name (the latter, if available).
-   * @throws WmException In case a connection error occurs, malformed data are sent, or the given brand name parameter does not exist in WM server.
+   * @return An array of com.scientiamobile.wurfl.wmclient.Model#JSONModelMktName (exposed by Java client API) that contain values for model_name
+   *         and marketing_name (the latter, if available). Throws WmException In case a connection error occurs, malformed data are sent, or the given brand name parameter does not exist in WM server.
    */
   def getAllDevicesForMake(make: String): Array[Model#JSONModelMktName] = wmjclient.getAllDevicesForMake(make)
 
   /**
-   * @return an array of all devices device_os capabilities in WM server
-   * @throws WmException In case a connection error occurs or malformed data are sent
+   * @return an array of all devices device_os capabilities in WM server. Throws WmException In case a connection error occurs, malformed data are sent,
+   *         or the given brand name parameter does not exist in WM server.
    */
   def getAllOSes(): Array[String] = wmjclient.getAllOSes
 
@@ -86,8 +85,8 @@ class WmClient(private var wmjclient: com.scientiamobile.wurfl.wmclient.WmClient
    * returns a slice
    *
    * @param osName a device OS name
-   * @return an array containing device_os_version for the given os_name
-   * @throws WmException In case a connection error occurs or malformed data are sent
+   * @return an array containing device_os_version for the given os_name. Throws WmException In case a connection error occurs, malformed data are sent,
+   *         or the given brand name parameter does not exist in WM server.
    */
   def getAllVersionsForOS(osName: String): Array[String] = wmjclient.getAllVersionsForOS(osName)
 
@@ -125,9 +124,8 @@ class WmClient(private var wmjclient: com.scientiamobile.wurfl.wmclient.WmClient
 
   /**
    * Deallocates all resources used by client. All subsequent usage of client will result in a WmException (you need to create the client again
-   * with a call to WmClient.apply.
+   * with a call to WmClient.apply. Throws WmException In case a connection error occurs, malformed data are sent, or the given brand name parameter does not exist in WM server.
    *
-   * @throws WmException In case of closing connection errors.
    */
   def destroyConnection() = wmjclient.destroyConnection
 

--- a/wmclient/src/main/scala/com/scientiamobile/wurfl/wmclient/scala/WmClient.scala
+++ b/wmclient/src/main/scala/com/scientiamobile/wurfl/wmclient/scala/WmClient.scala
@@ -1,3 +1,15 @@
+/*
+Copyright 2020 ScientiaMobile Inc. http://www.scientiamobile.com
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package com.scientiamobile.wurfl.wmclient.scala
 
 import java.util


### PR DESCRIPTION
- This PR is the initial release of WM Scala client API. It provides:
   - wrapper methods around Java Client API (which are needed to build and run Scala API)
   - both SBT and Maven build files.
   - A Scala style apply() method to handle client creation
   - An example API

Version number is aligned with Java client API: